### PR TITLE
Add support for executing commands on device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 _build/
 _flatpak/
 .flatpak-builder/
+po/*.pot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "artifex-batch",
  "artifex-rpc",
  "async-channel",
+ "chrono",
  "gettext-rs",
  "gtk4",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tokio = { version = "1.44", features = ["time", "rt-multi-thread", "sync"] }
 tonic = "0.11"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+chrono = "0.4.40"

--- a/HACKING.md
+++ b/HACKING.md
@@ -27,7 +27,7 @@ Translating requires the following tools:
 To generate the template:
 
 ```sh
-find src -name '*.rs' -exec xtr -o po/code.pot
+find src -name '*.rs' -exec xtr -o po/code.pot {} +
 xgettext --from-code=UTF-8 _build/data/resources/ui/*.ui data/resources/ui/*.ui -o po/ui.pot
 msgcat po/code.pot po/ui.pot > po/artifex-client-gtk.pot
 ```

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -4,8 +4,12 @@
     <!-- see https://gtk-rs.org/gtk4-rs/git/docs/gtk4/struct.Application.html#automatic-resources -->
     <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/batch_execution_page.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/command_bar.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/commands_row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/commands_view.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/connection_bar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/connection_status_page.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/execution_page.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/inspection_page.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/operation_page.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/operations_row.ui</file>

--- a/data/resources/ui/command_bar.blp
+++ b/data/resources/ui/command_bar.blp
@@ -1,0 +1,43 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+using Gtk 4.0;
+using Adw 1;
+
+template $CommandBar : Adw.Bin {
+  Gtk.Box {
+    hexpand: true;
+    [start]
+    Gtk.Entry command_entry {
+      hexpand: true;
+      tooltip-text: _("Command to execute");
+      placeholder-text: _("Enter a command");
+    }
+    [end]
+    Gtk.Button execute_button {
+      icon-name: "send-to-symbolic";
+      action-name: "execution-page.execute-command";
+      valign: center;
+      tooltip-text: _("Execute command");
+      styles ["accent", "circular", "suggested-action"]
+    }
+    Gtk.Popover command_popover {
+      position: bottom;
+      Gtk.Label command_popover_label {
+        halign: center;
+        margin-bottom: 6;
+        margin-end: 6;
+        margin-start: 6;
+        margin-top: 6;
+        valign: center;
+        wrap: true;
+      }
+    }
+    styles ["toolbar"]
+  }
+}

--- a/data/resources/ui/commands_row.blp
+++ b/data/resources/ui/commands_row.blp
@@ -1,0 +1,49 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+using Gtk 4.0;
+using Adw 1;
+
+template $CommandsRow : Gtk.ListBoxRow {
+  can-focus: false;
+  child: Gtk.Box {
+    orientation: vertical;
+    spacing: 12;
+    margin-bottom: 12;
+    margin-top: 12;
+    margin-start: 6;
+    margin-end: 6;
+    Gtk.Box {
+      spacing: 6;
+      [start]
+      Gtk.Label timestamp_label {}
+      [end]
+      Gtk.Stack status_stack {
+        Gtk.StackPage {
+          name: "status-ko";
+          child: Gtk.Image status_ko_img {
+            icon-name: "process-stop-symbolic";
+          };
+        }
+        Gtk.StackPage {
+          name: "status-ok";
+          child: Gtk.Image status_ok_img {
+            icon-name: "checkmark-symbolic";
+          };
+        }
+        Gtk.StackPage {
+          name: "status-running";
+          child: Adw.Spinner status_run_spinner {};
+        }
+      }
+    }
+    Gtk.Label text_label {
+      xalign: 0;
+    }
+  };
+}

--- a/data/resources/ui/commands_view.blp
+++ b/data/resources/ui/commands_view.blp
@@ -1,0 +1,20 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+using Gtk 4.0;
+
+template $CommandsView : Gtk.Box {
+  orientation: vertical;
+  vexpand: true;
+  Gtk.ScrolledWindow {
+    vexpand: true;
+    Gtk.ListView list_view {
+        single-click-activate: false;
+    }
+  }
+}

--- a/data/resources/ui/execution_page.blp
+++ b/data/resources/ui/execution_page.blp
@@ -1,0 +1,36 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+using Gtk 4.0;
+using Adw 1;
+
+template $ExecutionPage : $OperationPage {
+  Adw.Bin {
+    margin-top: 18;
+    margin-bottom: 18;
+    margin-start: 18;
+    margin-end: 18;
+
+    Gtk.Box {
+      orientation: vertical;
+      [start]
+      $CommandsView commands_view {}
+      [end]
+      $CommandBar command_bar {}
+    }
+
+    ShortcutController {
+      scope: managed;
+      propagation-phase: capture;
+      Shortcut {
+        trigger: "<Control>x";
+        action: "action(execution-page.execute-command)";
+      }
+    }
+  }
+}

--- a/data/resources/ui/meson.build
+++ b/data/resources/ui/meson.build
@@ -10,8 +10,12 @@ blueprints = custom_target(
   'blueprints',
   input: files(
     'batch_execution_page.blp',
+    'command_bar.blp',
+    'commands_row.blp',
+    'commands_view.blp',
     'connection_bar.blp',
     'connection_status_page.blp',
+    'execution_page.blp',
     'inspection_page.blp',
     'operation_page.blp',
     'operations_row.blp',

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -46,6 +46,17 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcut window">System Execution</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Execute command</property>
+                <property name="accelerator">&lt;Control&gt;x</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
             <property name="title" translatable="yes" context="shortcut window">Batch Execution</property>
             <child>
               <object class="GtkShortcutsShortcut">

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -65,6 +65,11 @@
                    page-name: "inspection";
                    tooltip-text: _("Inspect the device");
                  }
+                 $OperationsRow {
+                   title: _("Execution");
+                   page-name: "execution";
+                   tooltip-text: _("Execute a command on the device");
+                 }
                  Gtk.ListBoxRow {
                    activatable: false;
                    selectable: false;
@@ -96,6 +101,10 @@
          Gtk.StackPage {
            name: "inspection";
            child: $InspectionPage inspection_page {};
+         }
+         Gtk.StackPage {
+           name: "execution";
+           child: $ExecutionPage execution_page {};
          }
          Gtk.StackPage {
            name: "batch_execution";

--- a/po/fr.po
+++ b/po/fr.po
@@ -5,10 +5,9 @@
 #
 msgid ""
 msgstr ""
-"#-#-#-#-#  code.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: artifex-client-gtk 0.1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-17 09:46+0000\n"
+"POT-Creation-Date: 2025-04-22 20:18+0000\n"
 "PO-Revision-Date: 2025-04-17 11:47+0200\n"
 "Last-Translator: Éric Le Bihan <eric.le.bihan.dev@free.fr>\n"
 "Language-Team: French\n"
@@ -16,64 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"#-#-#-#-#  code.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-
-#: src/application.rs:128
-msgid "translator-credits"
-msgstr ""
-
-#: src/widgets/batch_execution_page.rs:81
-msgid "Batch Execution"
-msgstr "Exécution de batch"
-
-#: src/widgets/batch_execution_page.rs:84
-msgid "Open batch file"
-msgstr "Ouvrir un ficher batch"
-
-#: src/widgets/batch_execution_page.rs:93
-msgid "Execute batch"
-msgstr "Exécuter le batch"
-
-#: src/widgets/batch_execution_page.rs:122
-msgid "Batch files"
-msgstr "Fichiers batch"
-
-#: src/widgets/batch_execution_page.rs:125
-msgid "Select batch file"
-msgstr "Sélectionner un fichier batch"
-
-#: src/widgets/batch_execution_page.rs:143
-msgid "Invalid file"
-msgstr "Fichier invalide"
-
-#: src/widgets/batch_execution_page.rs:148
-msgid "Invalid file name"
-msgstr "Nom de fichier invalide"
-
-#: src/widgets/batch_execution_page.rs:164
-msgid "Failed to read file"
-msgstr "Impossible de lire le fichier"
-
-#: src/widgets/batch_execution_page.rs:169
-#: src/widgets/batch_execution_page.rs:174
-msgid "Failed to load batch"
-msgstr "Impossible de charger le batch"
-
-#: src/widgets/batch_execution_page.rs:205
-msgid "Invalid batch"
-msgstr "Batch invalide"
-
-#: src/widgets/batch_execution_page.rs:237
-msgid "Failed to render report"
-msgstr "Impossible de générer le rapport"
-
-#: src/widgets/batch_execution_page.rs:242
-msgid "Failed to run batch"
-msgstr "Impossible de lancer le batch"
-
-#: src/widgets/batch_execution_page.rs:256
-msgid "Batch output copied"
-msgstr "Sortie du batch copiée"
 
 #: src/widgets/connection_status_page.rs:59
 msgid "Connected"
@@ -91,27 +34,100 @@ msgstr "Non connecté"
 msgid "Enter server address and press \"Connect\"."
 msgstr "Entrez l'adresse du serveur et pressez \"Connexion\""
 
-#: src/widgets/inspection_page.rs:61 _build/data/resources/ui/window.ui:75
-msgid "Inspection"
-msgstr "Inspection"
-
-#: src/widgets/inspection_page.rs:64
-msgid "Refresh information"
-msgstr "Rafraîchir les informations"
-
 #: src/widgets/operation_page.rs:101
 msgid "Close"
 msgstr "Fermer"
 
-#: src/window.rs:251
+#: src/widgets/inspection_page.rs:61 src/pages/inspection_page.rs:61
+#: _build/data/resources/ui/window.ui:75
+msgid "Inspection"
+msgstr "Inspection"
+
+#: src/widgets/inspection_page.rs:64 src/pages/inspection_page.rs:64
+msgid "Refresh information"
+msgstr "Rafraîchir les informations"
+
+#: src/widgets/batch_execution_page.rs:81 src/pages/batch_execution_page.rs:81
+msgid "Batch Execution"
+msgstr "Exécution de batch"
+
+#: src/widgets/batch_execution_page.rs:84 src/pages/batch_execution_page.rs:84
+msgid "Open batch file"
+msgstr "Ouvrir un ficher batch"
+
+#: src/widgets/batch_execution_page.rs:93 src/pages/batch_execution_page.rs:93
+msgid "Execute batch"
+msgstr "Exécuter le batch"
+
+#: src/widgets/batch_execution_page.rs:122
+#: src/pages/batch_execution_page.rs:122
+msgid "Batch files"
+msgstr "Fichiers batch"
+
+#: src/widgets/batch_execution_page.rs:125
+#: src/pages/batch_execution_page.rs:125
+msgid "Select batch file"
+msgstr "Sélectionner un fichier batch"
+
+#: src/widgets/batch_execution_page.rs:143
+#: src/pages/batch_execution_page.rs:143
+msgid "Invalid file"
+msgstr "Fichier invalide"
+
+#: src/widgets/batch_execution_page.rs:148
+#: src/pages/batch_execution_page.rs:148
+msgid "Invalid file name"
+msgstr "Nom de fichier invalide"
+
+#: src/widgets/batch_execution_page.rs:164
+#: src/pages/batch_execution_page.rs:164
+msgid "Failed to read file"
+msgstr "Impossible de lire le fichier"
+
+#: src/widgets/batch_execution_page.rs:169
+#: src/widgets/batch_execution_page.rs:174
+#: src/pages/batch_execution_page.rs:169 src/pages/batch_execution_page.rs:174
+msgid "Failed to load batch"
+msgstr "Impossible de charger le batch"
+
+#: src/widgets/batch_execution_page.rs:205
+#: src/pages/batch_execution_page.rs:205
+msgid "Invalid batch"
+msgstr "Batch invalide"
+
+#: src/widgets/batch_execution_page.rs:237
+#: src/pages/batch_execution_page.rs:237
+msgid "Failed to render report"
+msgstr "Impossible de générer le rapport"
+
+#: src/widgets/batch_execution_page.rs:242
+#: src/pages/batch_execution_page.rs:242
+msgid "Failed to run batch"
+msgstr "Impossible de lancer le batch"
+
+#: src/widgets/batch_execution_page.rs:256
+#: src/pages/batch_execution_page.rs:256
+msgid "Batch output copied"
+msgstr "Sortie du batch copiée"
+
+#: src/application.rs:128
+msgid "translator-credits"
+msgstr ""
+
+#: src/pages/execution/execution_page.rs:65
+#: _build/data/resources/ui/window.ui:82 _build/data/resources/ui/window.ui:104
+msgid "Execution"
+msgstr "Exécution"
+
+#: src/window.rs:256
 msgid "Connection failed"
 msgstr "La connexion a échouée"
 
-#: src/window.rs:253
+#: src/window.rs:258
 msgid "Ok"
 msgstr "Ok"
 
-#: src/window.rs:275
+#: src/window.rs:280
 msgid "Please enter a valid URL"
 msgstr "Veuillez entrer une URL valide"
 
@@ -122,6 +138,18 @@ msgstr "Sortie"
 #: _build/data/resources/ui/batch_execution_page.ui:54
 msgid "Copy output "
 msgstr "Copier la sortie"
+
+#: _build/data/resources/ui/command_bar.ui:16
+msgid "Command to execute"
+msgstr "Commande à exécuter"
+
+#: _build/data/resources/ui/command_bar.ui:17
+msgid "Enter a command"
+msgstr "Entrez une commande"
+
+#: _build/data/resources/ui/command_bar.ui:25
+msgid "Execute command"
+msgstr "Exécuter la commande"
 
 #: _build/data/resources/ui/connection_bar.ui:16
 msgid "URL of the server"
@@ -159,23 +187,23 @@ msgstr "Système"
 msgid "Inspect the device"
 msgstr "Inspecter l'appareil"
 
-#: _build/data/resources/ui/window.ui:86
+#: _build/data/resources/ui/window.ui:84
+msgid "Execute a command on the device"
+msgstr "Exécuter une commande sur l'appareil"
+
+#: _build/data/resources/ui/window.ui:93
 msgid "Batch"
 msgstr "Batch"
 
-#: _build/data/resources/ui/window.ui:97
-msgid "Execution"
-msgstr "Exécution"
-
-#: _build/data/resources/ui/window.ui:99
+#: _build/data/resources/ui/window.ui:106
 msgid "Execute a batch"
 msgstr "Exécuter un batch"
 
-#: _build/data/resources/ui/window.ui:155
+#: _build/data/resources/ui/window.ui:170
 msgid "About artifex-client-gtk"
 msgstr "À propos d'artifex-client-gtk"
 
-#: _build/data/resources/ui/window.ui:159
+#: _build/data/resources/ui/window.ui:174
 msgid "Show shortcuts"
 msgstr "Afficher les raccourcis"
 
@@ -216,20 +244,30 @@ msgstr "Rafraîchir les informations"
 
 #: data/resources/ui/shortcuts.ui:49
 msgctxt "shortcut window"
+msgid "System Execution"
+msgstr "Exécution sur le système"
+
+#: data/resources/ui/shortcuts.ui:52
+msgctxt "shortcut window"
+msgid "Execute command"
+msgstr "Exécuter une commande"
+
+#: data/resources/ui/shortcuts.ui:60
+msgctxt "shortcut window"
 msgid "Batch Execution"
 msgstr "Exécution de batch"
 
-#: data/resources/ui/shortcuts.ui:52
+#: data/resources/ui/shortcuts.ui:63
 msgctxt "shortcut window"
 msgid "Open batch"
 msgstr "Ouvrir un batch"
 
-#: data/resources/ui/shortcuts.ui:58
+#: data/resources/ui/shortcuts.ui:69
 msgctxt "shortcut window"
 msgid "Execute batch"
 msgstr "Exécuter un batch"
 
-#: data/resources/ui/shortcuts.ui:64
+#: data/resources/ui/shortcuts.ui:75
 msgctxt "shortcut window"
 msgid "Copy output"
 msgstr "Copier la sortie"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod config {
 mod application;
 mod client;
 mod i18n;
+mod pages;
 mod widgets;
 mod window;
 

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,0 +1,13 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+mod batch_execution_page;
+mod inspection_page;
+
+pub use batch_execution_page::*;
+pub use inspection_page::*;

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -7,7 +7,9 @@
 //
 
 mod batch_execution_page;
+mod execution;
 mod inspection_page;
 
 pub use batch_execution_page::*;
+pub use execution::*;
 pub use inspection_page::*;

--- a/src/pages/batch_execution_page.rs
+++ b/src/pages/batch_execution_page.rs
@@ -1,0 +1,263 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use adw::{prelude::*, subclass::prelude::*};
+use artifex_batch::{Batch, BatchReport, BatchRunner, MarkupKind, MarkupReportRenderer};
+use gettextrs::gettext;
+use gtk::{gio, glib};
+use tracing::{debug, error};
+
+use crate::{
+    client,
+    widgets::{OperationPage, OperationPageImpl},
+};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/batch_execution_page.ui")]
+    pub struct BatchExecutionPage {
+        pub open_button: gtk::Button,
+        pub exec_button: gtk::Button,
+        #[template_child]
+        pub input_text_view: TemplateChild<gtk::TextView>,
+        #[template_child]
+        pub output_view: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub output_text_view: TemplateChild<gtk::TextView>,
+        pub activity_spinner: adw::Spinner,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for BatchExecutionPage {
+        const NAME: &'static str = "BatchExecutionPage";
+        type Type = super::BatchExecutionPage;
+        type ParentType = OperationPage;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.install_action_async(
+                "batch-execution-page.open-batch",
+                None,
+                async move |page, _, _| {
+                    debug!("batch-execution-page.open-batch");
+                    page.open_batch().await
+                },
+            );
+            klass.install_action_async(
+                "batch-execution-page.exec-batch",
+                None,
+                async move |page, _, _| {
+                    debug!("batch-execution-page.exec-batch");
+                    page.exec_batch().await
+                },
+            );
+            klass.install_action(
+                "batch-execution-page.copy-output",
+                None,
+                move |page, _, _| {
+                    debug!("batch-execution-page.copy-output");
+                    page.copy_output()
+                },
+            )
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for BatchExecutionPage {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.obj()
+                .upcast_ref::<OperationPage>()
+                .set_title(&gettext("Batch Execution"));
+            self.open_button.set_icon_name("folder-open-symbolic");
+            self.open_button
+                .set_tooltip_text(Some(&gettext("Open batch file")));
+            self.open_button
+                .set_action_name(Some("batch-execution-page.open-batch"));
+            let header_bar = self.obj().upcast_ref::<OperationPage>().get_header_bar();
+            header_bar.pack_start(&self.open_button);
+            self.activity_spinner.set_visible(false);
+            self.exec_button
+                .set_icon_name("media-playback-start-symbolic");
+            self.exec_button
+                .set_tooltip_text(Some(&gettext("Execute batch")));
+            self.exec_button
+                .set_action_name(Some("batch-execution-page.exec-batch"));
+            let exec_box = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+            exec_box.append(&self.activity_spinner);
+            exec_box.append(&self.exec_button);
+            header_bar.pack_end(&exec_box);
+            self.obj().enable_input_actions(false);
+            self.obj().enable_output_actions(false);
+        }
+        fn dispose(&self) {
+            self.dispose_template();
+        }
+    }
+
+    impl WidgetImpl for BatchExecutionPage {}
+    impl BinImpl for BatchExecutionPage {}
+    impl OperationPageImpl for BatchExecutionPage {}
+}
+
+glib::wrapper! {
+    pub struct BatchExecutionPage(ObjectSubclass<imp::BatchExecutionPage>)
+        @extends gtk::Widget, adw::Bin, OperationPage;
+}
+
+impl BatchExecutionPage {
+    async fn open_batch(&self) {
+        let filter = gtk::FileFilter::new();
+        filter.add_pattern("*.txt");
+        filter.set_name(Some(&gettext("Batch files")));
+        let dialog = gtk::FileDialog::builder()
+            .modal(true)
+            .title(&gettext("Select batch file"))
+            .default_filter(&filter)
+            .build();
+        match dialog
+            .open_future(self.root().and_downcast_ref::<gtk::Window>())
+            .await
+        {
+            Ok(file) => {
+                debug!("Opening {:?}", file.path());
+                self.load_batch(file)
+            }
+            Err(e) => {
+                error!("Failed to open file: {e}")
+            }
+        }
+    }
+
+    fn load_batch(&self, file: gio::File) {
+        match file.path().ok_or_else(|| gettext("Invalid file")) {
+            Ok(path) => {
+                match path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .ok_or_else(|| gettext("Invalid file name"))
+                {
+                    Ok(file_name) => {
+                        self.upcast_ref::<OperationPage>()
+                            .imp()
+                            .window_title
+                            .set_subtitle(&file_name);
+                        match std::fs::read_to_string(path) {
+                            Ok(text) => {
+                                self.imp().input_text_view.buffer().set_text(&text);
+                                self.imp().output_text_view.buffer().set_text("");
+                                self.enable_input_actions(true);
+                                self.enable_output_actions(false);
+                            }
+                            Err(e) => self
+                                .upcast_ref::<OperationPage>()
+                                .show_error(&gettext("Failed to read file"), &e.to_string()),
+                        }
+                    }
+                    Err(e) => self
+                        .upcast_ref::<OperationPage>()
+                        .show_error(&gettext("Failed to load batch"), &e.to_string()),
+                }
+            }
+            Err(e) => self
+                .upcast_ref::<OperationPage>()
+                .show_error(&gettext("Failed to load batch"), &e.to_string()),
+        }
+    }
+
+    fn enable_input_actions(&self, enabled: bool) {
+        self.imp().exec_button.set_sensitive(enabled);
+        self.imp().input_text_view.set_sensitive(enabled);
+    }
+
+    fn enable_output_actions(&self, enabled: bool) {
+        self.imp().output_view.set_sensitive(enabled);
+    }
+
+    pub fn set_busy(&self, busy: bool) {
+        self.upcast_ref::<OperationPage>().set_busy(busy);
+        self.imp().activity_spinner.set_visible(busy);
+        self.enable_input_actions(!busy);
+    }
+
+    async fn exec_batch(&self) {
+        self.imp().output_text_view.buffer().set_text("");
+        let buffer = self.imp().input_text_view.buffer();
+        match Batch::from_reader(
+            buffer
+                .text(&buffer.start_iter(), &buffer.end_iter(), false)
+                .as_str()
+                .as_bytes(),
+        ) {
+            Ok(batch) => self.run_batch(batch).await,
+            Err(e) => self
+                .upcast_ref::<OperationPage>()
+                .show_error(&gettext("Invalid batch"), &e.to_string()),
+        }
+    }
+
+    async fn run_batch(&self, batch: Batch) {
+        let client = self.upcast_ref::<OperationPage>().imp().client.borrow();
+        if let Some(client) = client.clone() {
+            self.set_busy(true);
+            let (sender, receiver) =
+                async_channel::bounded::<Result<BatchReport, artifex_batch::Error>>(1);
+            client::runtime().spawn(async move {
+                let mut client = client.lock().await;
+                let mut runner = BatchRunner::new(&mut client);
+                let result = runner.run(&batch).await;
+                sender
+                    .send(result)
+                    .await
+                    .expect("The channel needs to be open")
+            });
+            while let Ok(result) = receiver.recv().await {
+                match result {
+                    Ok(report) => {
+                        let mut buffer = Vec::new();
+                        let renderer = MarkupReportRenderer::new(MarkupKind::Yaml);
+                        match renderer
+                            .render(&mut buffer, &report)
+                            .map_err(|e| e.to_string())
+                            .and_then(|()| String::from_utf8(buffer).map_err(|e| e.to_string()))
+                        {
+                            Ok(text) => self.imp().output_text_view.buffer().set_text(&text),
+                            Err(e) => self
+                                .upcast_ref::<OperationPage>()
+                                .show_error(&gettext("Failed to render report"), &e.to_string()),
+                        }
+                    }
+                    Err(e) => self
+                        .upcast_ref::<OperationPage>()
+                        .show_error(&gettext("Failed to run batch"), &e.to_string()),
+                }
+            }
+            self.set_busy(false);
+            self.enable_output_actions(true);
+        }
+    }
+
+    fn copy_output(&self) {
+        let clipboard = self.clipboard();
+        let buffer = self.imp().output_text_view.buffer();
+        let text = buffer.text(&buffer.start_iter(), &buffer.end_iter(), false);
+        clipboard.set_text(&text);
+        let toast = adw::Toast::builder()
+            .title(&gettext("Batch output copied"))
+            .build();
+        self.upcast_ref::<OperationPage>()
+            .imp()
+            .toast_overlay
+            .add_toast(toast);
+    }
+}

--- a/src/pages/execution.rs
+++ b/src/pages/execution.rs
@@ -1,0 +1,19 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+mod command;
+mod command_bar;
+mod commands_row;
+mod commands_view;
+mod execution_page;
+
+pub use command::{Command, CommandStatus};
+pub(self) use command_bar::*;
+pub(self) use commands_row::*;
+pub(self) use commands_view::*;
+pub use execution_page::ExecutionPage;

--- a/src/pages/execution/command.rs
+++ b/src/pages/execution/command.rs
@@ -1,0 +1,108 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use chrono::Local;
+use gtk::{glib, glib::Properties, prelude::*, subclass::prelude::*};
+use std::cell::RefCell;
+use std::fmt::Display;
+
+#[derive(Clone, Copy, Debug, glib::Enum, PartialEq, Default)]
+#[enum_type(name = "CommandDirection")]
+#[repr(u32)]
+pub enum CommandDirection {
+    #[default]
+    Input,
+    Output,
+}
+
+impl Display for CommandDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Input => write!(f, "input"),
+            Self::Output => write!(f, "output"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, glib::Enum, PartialEq, Default)]
+#[enum_type(name = "CommandStatus")]
+#[repr(u32)]
+pub enum CommandStatus {
+    Ko,
+    Ok,
+    #[default]
+    Running,
+}
+
+impl Display for CommandStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ko => write!(f, "ko"),
+            Self::Ok => write!(f, "ok"),
+            Self::Running => write!(f, "running"),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CommandData {
+    pub direction: CommandDirection,
+    pub timestamp: String,
+    pub status: CommandStatus,
+    pub text: String,
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, Properties)]
+    #[properties(wrapper_type = super::Command)]
+    pub struct Command {
+        #[property(name = "direction", get, set, type = CommandDirection, member = direction, builder(CommandDirection::Input))]
+        #[property(name = "timestamp", get, set, type = String, member = timestamp)]
+        #[property(name = "status", get, set, type = CommandStatus, member = status, builder(CommandStatus::Running))]
+        #[property(name = "text", get, set, type = String, member = text)]
+        pub(crate) data: RefCell<CommandData>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Command {
+        const NAME: &'static str = "Command";
+        type Type = super::Command;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for Command {}
+}
+
+glib::wrapper! {
+    pub struct Command(ObjectSubclass<imp::Command>);
+}
+
+impl Command {
+    pub fn new(text: &str) -> Self {
+        glib::Object::builder()
+            .property("text", text)
+            .property(
+                "timestamp",
+                &format!("{}", Local::now().format("%d/%m/%Y %H:%M:%S")),
+            )
+            .build()
+    }
+}
+
+impl From<CommandData> for Command {
+    fn from(value: CommandData) -> Self {
+        glib::Object::builder()
+            .property("direction", value.direction)
+            .property("timestamp", &value.timestamp)
+            .property("status", value.status)
+            .property("text", &value.text)
+            .build()
+    }
+}

--- a/src/pages/execution/command_bar.rs
+++ b/src/pages/execution/command_bar.rs
@@ -1,0 +1,87 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use adw::subclass::prelude::*;
+use gtk::{glib, prelude::*};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/command_bar.ui")]
+    pub struct CommandBar {
+        #[template_child]
+        pub command_entry: TemplateChild<gtk::Entry>,
+        #[template_child]
+        pub execute_button: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub command_popover: TemplateChild<gtk::Popover>,
+        #[template_child]
+        pub command_popover_label: TemplateChild<gtk::Label>,
+    }
+
+    impl Default for CommandBar {
+        fn default() -> Self {
+            Self {
+                command_entry: TemplateChild::default(),
+                execute_button: TemplateChild::default(),
+                command_popover: TemplateChild::default(),
+                command_popover_label: TemplateChild::default(),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for CommandBar {
+        const NAME: &'static str = "CommandBar";
+        type Type = super::CommandBar;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for CommandBar {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.command_entry
+                .bind_property("text", &*self.execute_button, "sensitive")
+                .sync_create()
+                .transform_to(|_, text: String| Some(!text.is_empty()))
+                .build();
+        }
+        fn dispose(&self) {
+            self.dispose_template();
+        }
+    }
+
+    impl WidgetImpl for CommandBar {}
+    impl BinImpl for CommandBar {}
+}
+
+glib::wrapper! {
+    pub struct CommandBar(ObjectSubclass<imp::CommandBar>)
+        @extends gtk::Widget, adw::Bin;
+}
+
+impl CommandBar {
+    /// Show COMMAND popover to display `message`.
+    pub fn show_popover(&self, message: &str) {
+        self.imp().command_popover.popup();
+        self.imp().command_popover_label.set_text(message);
+    }
+    /// Get the command to execute.
+    pub fn command(&self) -> String {
+        self.imp().command_entry.buffer().text().to_string()
+    }
+}

--- a/src/pages/execution/commands_row.rs
+++ b/src/pages/execution/commands_row.rs
@@ -1,0 +1,123 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use super::{Command, CommandStatus};
+use gtk::{glib, prelude::*};
+use std::cell::{Cell, RefCell};
+
+mod imp {
+    use gtk::subclass::prelude::*;
+    use std::marker::PhantomData;
+
+    use super::*;
+
+    #[derive(Debug, Default, glib::Properties, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/commands_row.ui")]
+    #[properties(wrapper_type = super::CommandsRow)]
+    pub struct CommandsRow {
+        #[template_child]
+        pub timestamp_label: gtk::TemplateChild<gtk::Label>,
+        #[template_child]
+        pub status_stack: gtk::TemplateChild<gtk::Stack>,
+        #[template_child]
+        pub text_label: TemplateChild<gtk::Label>,
+        #[property(
+            type = String,
+            set = Self::set_timestamp)]
+        timestamp: PhantomData<String>,
+        #[property(
+            type = String,
+            set = Self::set_text
+            )]
+        text: PhantomData<String>,
+        #[property(type = CommandStatus, get, set = Self::set_status, builder(CommandStatus::default()))]
+        pub status: Cell<CommandStatus>,
+        #[property(get, set = Self::set_command, explicit_notify, nullable)]
+        pub command: glib::WeakRef<Command>,
+        pub bindings: RefCell<Vec<glib::Binding>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for CommandsRow {
+        const NAME: &'static str = "CommandsRow";
+        type Type = super::CommandsRow;
+        type ParentType = gtk::ListBoxRow;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for CommandsRow {}
+    impl WidgetImpl for CommandsRow {}
+    impl ListBoxRowImpl for CommandsRow {}
+    impl CommandsRow {
+        fn set_status(&self, status: CommandStatus) {
+            let page_name = match status {
+                CommandStatus::Ko => "status-ko",
+                CommandStatus::Ok => "status-ok",
+                CommandStatus::Running => "status-running",
+            };
+            self.status_stack.set_visible_child_name(&page_name);
+        }
+        fn set_timestamp(&self, timestamp: &str) {
+            self.timestamp_label.set_text(timestamp);
+        }
+        fn set_text(&self, text: &str) {
+            self.text_label.set_text(text);
+        }
+        fn set_command(&self, command: Option<&Command>) {
+            if self.command.upgrade().as_ref() == command {
+                return;
+            }
+            for binding in self.bindings.take() {
+                binding.unbind();
+            }
+            if let Some(command) = command {
+                let timestamp_binding = command
+                    .bind_property("timestamp", &*self.timestamp_label, "label")
+                    .bidirectional()
+                    .sync_create()
+                    .build();
+                let text_binding = command
+                    .bind_property("text", &*self.text_label, "label")
+                    .bidirectional()
+                    .sync_create()
+                    .build();
+                let status_binding = command
+                    .bind_property("status", &*self.obj(), "status")
+                    .bidirectional()
+                    .sync_create()
+                    .build();
+                self.bindings.borrow_mut().extend([
+                    timestamp_binding,
+                    text_binding,
+                    status_binding,
+                ]);
+            }
+            self.command.set(command);
+            self.obj().notify_command();
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct CommandsRow(ObjectSubclass<imp::CommandsRow>)
+        @extends gtk::Widget, gtk::ListBoxRow;
+}
+
+impl CommandsRow {
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+}

--- a/src/pages/execution/commands_view.rs
+++ b/src/pages/execution/commands_view.rs
@@ -1,0 +1,63 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use gtk::{glib, subclass::prelude::*};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/commands_view.ui")]
+    pub struct CommandsView {
+        #[template_child]
+        pub list_view: TemplateChild<gtk::ListView>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for CommandsView {
+        const NAME: &'static str = "CommandsView";
+        type Type = super::CommandsView;
+        type ParentType = gtk::Box;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for CommandsView {
+        fn constructed(&self) {
+            self.parent_constructed();
+        }
+
+        fn dispose(&self) {
+            self.dispose_template();
+        }
+    }
+
+    impl WidgetImpl for CommandsView {}
+    impl BoxImpl for CommandsView {}
+}
+
+glib::wrapper! {
+    pub struct CommandsView(ObjectSubclass<imp::CommandsView>)
+        @extends gtk::Widget, gtk::Box;
+}
+
+impl CommandsView {
+    pub fn set_model(&self, model: Option<&impl glib::object::IsA<gtk::SelectionModel>>) {
+        self.imp().list_view.set_model(model)
+    }
+
+    pub fn set_factory(&self, factory: Option<&impl glib::object::IsA<gtk::ListItemFactory>>) {
+        self.imp().list_view.set_factory(factory)
+    }
+}

--- a/src/pages/execution/execution_page.rs
+++ b/src/pages/execution/execution_page.rs
@@ -1,0 +1,198 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use adw::{prelude::*, subclass::prelude::*};
+use artifex_rpc::{ExecuteReply, ExecuteRequest};
+use gettextrs::gettext;
+use gtk::{gio, glib};
+use tracing::{debug, error};
+
+use crate::{
+    client,
+    widgets::{OperationPage, OperationPageImpl},
+};
+
+use super::{
+    command::CommandDirection, Command, CommandBar, CommandStatus, CommandsRow, CommandsView,
+};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/execution_page.ui")]
+    pub struct ExecutionPage {
+        #[template_child]
+        pub commands_view: TemplateChild<CommandsView>,
+        #[template_child]
+        pub command_bar: TemplateChild<CommandBar>,
+        pub(crate) commands: gio::ListStore,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ExecutionPage {
+        const NAME: &'static str = "ExecutionPage";
+        type Type = super::ExecutionPage;
+        type ParentType = OperationPage;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.install_action_async(
+                "execution-page.execute-command",
+                None,
+                async move |page, _, _| {
+                    debug!("execution-page.execute-command");
+                    page.execute_command().await
+                },
+            );
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for ExecutionPage {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.obj()
+                .upcast_ref::<OperationPage>()
+                .set_title(&gettext("Execution"));
+            self.obj().setup_store();
+            self.obj().setup_factory();
+        }
+        fn dispose(&self) {
+            self.dispose_template();
+        }
+    }
+
+    impl Default for ExecutionPage {
+        fn default() -> Self {
+            Self {
+                commands: gio::ListStore::new::<Command>(),
+                command_bar: gtk::TemplateChild::default(),
+                commands_view: gtk::TemplateChild::default(),
+            }
+        }
+    }
+
+    impl WidgetImpl for ExecutionPage {}
+    impl BinImpl for ExecutionPage {}
+    impl OperationPageImpl for ExecutionPage {}
+}
+
+glib::wrapper! {
+    pub struct ExecutionPage(ObjectSubclass<imp::ExecutionPage>)
+        @extends gtk::Widget, adw::Bin, OperationPage;
+}
+
+impl ExecutionPage {
+    fn setup_store(&self) {
+        let selection_model = gtk::NoSelection::new(Some(self.imp().commands.clone()));
+        self.imp().commands_view.set_model(Some(&selection_model));
+    }
+
+    fn setup_factory(&self) {
+        let factory = gtk::SignalListItemFactory::new();
+        factory.connect_setup(move |_, list_item| {
+            let row = CommandsRow::new();
+            let list_item = list_item
+                .downcast_ref::<gtk::ListItem>()
+                .expect("Must be a ListItem");
+            list_item.set_child(Some(&row));
+        });
+        factory.connect_bind(move |_, list_item| {
+            let list_item = list_item
+                .downcast_ref::<gtk::ListItem>()
+                .expect("Must be a ListItem");
+            if let Some(command) = list_item
+                .downcast_ref::<gtk::ListItem>()
+                .expect("Must be to ListItem")
+                .item()
+                .and_downcast_ref::<Command>()
+            {
+                let child = list_item
+                    .downcast_ref::<gtk::ListItem>()
+                    .expect("Must be a ListItem")
+                    .child();
+                let row = child
+                    .and_downcast_ref::<CommandsRow>()
+                    .expect("Child must be a CommandsRow");
+                row.set_command(Some(command));
+            }
+        });
+        factory.connect_unbind(move |_, list_item| {
+            let row = list_item
+                .downcast_ref::<gtk::ListItem>()
+                .expect("Must be a ListItem")
+                .child()
+                .and_downcast::<CommandsRow>()
+                .expect("Child must be a CommandsRow");
+            row.set_command(None::<Command>);
+        });
+        self.imp().commands_view.set_factory(Some(&factory));
+    }
+
+    pub fn set_busy(&self, busy: bool) {
+        self.imp().command_bar.set_sensitive(!busy);
+    }
+
+    async fn execute_command(&self) {
+        let client = self.upcast_ref::<OperationPage>().imp().client.borrow();
+        if let Some(client) = client.clone() {
+            self.set_busy(true);
+            let cmd_text = self.imp().command_bar.command();
+            let cmd_input = Command::new(&cmd_text);
+            self.imp().commands.append(&cmd_input);
+            let (sender, receiver) =
+                async_channel::bounded::<Result<tonic::Response<ExecuteReply>, tonic::Status>>(1);
+            client::runtime().spawn(async move {
+                let mut client = client.lock().await;
+                let result = client.execute(ExecuteRequest { command: cmd_text }).await;
+                sender
+                    .send(result)
+                    .await
+                    .expect("The channel needs to be open")
+            });
+            while let Ok(result) = receiver.recv().await {
+                match result {
+                    Ok(response) => {
+                        self.set_current_command_input_status(CommandStatus::Ok);
+                        let reply = response.into_inner();
+                        let cmd_output = Command::new(&reply.stdout);
+                        cmd_output.set_direction(CommandDirection::Output);
+                        let status = if reply.code == 0 {
+                            CommandStatus::Ok
+                        } else {
+                            CommandStatus::Ko
+                        };
+                        cmd_output.set_status(status);
+                        self.imp().commands.append(&cmd_output);
+                    }
+                    Err(e) => {
+                        error!("Command execution failed: {}", e.to_string());
+                        self.set_current_command_input_status(CommandStatus::Ko)
+                    }
+                }
+                self.set_busy(false);
+            }
+        }
+    }
+
+    fn set_current_command_input_status(&self, status: CommandStatus) {
+        let n_items = self.imp().commands.n_items();
+        if let Some(command) = self
+            .imp()
+            .commands
+            .item(n_items - 1)
+            .and_downcast_ref::<Command>()
+        {
+            command.set_status(status);
+        }
+    }
+}

--- a/src/pages/inspection_page.rs
+++ b/src/pages/inspection_page.rs
@@ -1,0 +1,124 @@
+//
+// This file is part of artifex-client-gtk
+//
+// SPDX-FileCopyrightText: Copyright © 2025 Eric Le Bihan
+//
+// SPDX-License-Identifier: MIT
+//
+
+use adw::{prelude::*, subclass::prelude::*};
+use artifex_rpc::{InspectReply, InspectRequest};
+use gettextrs::gettext;
+use gtk::glib;
+use humantime::format_duration;
+use std::time::Duration;
+use tracing::debug;
+
+use crate::{
+    client,
+    widgets::{OperationPage, OperationPageImpl},
+};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, gtk::CompositeTemplate)]
+    #[template(resource = "/com/elebihan/artifex-client-gtk/ui/inspection_page.ui")]
+    pub struct InspectionPage {
+        pub refresh_button: gtk::Button,
+        #[template_child]
+        pub activity_spinner: TemplateChild<adw::Spinner>,
+        #[template_child]
+        pub kernel_version_row: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub system_uptime_row: TemplateChild<adw::ActionRow>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for InspectionPage {
+        const NAME: &'static str = "InspectionPage";
+        type Type = super::InspectionPage;
+        type ParentType = OperationPage;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.install_action_async("inspection-page.refresh", None, |page, _, _| async move {
+                debug!("InspectionPage::inspection-page.refresh");
+                page.refresh().await
+            });
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for InspectionPage {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.obj()
+                .upcast_ref::<OperationPage>()
+                .set_title(&gettext("Inspection"));
+            self.refresh_button.set_icon_name("view-refresh-symbolic");
+            self.refresh_button
+                .set_tooltip_text(Some(&gettext("Refresh information")));
+            self.refresh_button
+                .set_action_name(Some("inspection-page.refresh"));
+            let toolbar = gtk::Box::builder().build();
+            toolbar.append(&self.refresh_button);
+            let header_bar = self.obj().upcast_ref::<OperationPage>().get_header_bar();
+            header_bar.pack_end(&toolbar);
+        }
+        fn dispose(&self) {
+            self.dispose_template();
+        }
+    }
+
+    impl WidgetImpl for InspectionPage {}
+    impl BinImpl for InspectionPage {}
+    impl OperationPageImpl for InspectionPage {}
+}
+
+glib::wrapper! {
+    pub struct InspectionPage(ObjectSubclass<imp::InspectionPage>)
+        @extends gtk::Widget, adw::Bin, OperationPage;
+}
+
+impl InspectionPage {
+    pub async fn refresh(&self) {
+        let client = self.upcast_ref::<OperationPage>().imp().client.borrow();
+        if let Some(client) = client.clone() {
+            self.set_busy(true);
+            let (sender, receiver) =
+                async_channel::bounded::<Result<tonic::Response<InspectReply>, tonic::Status>>(1);
+            client::runtime().spawn(async move {
+                let mut client = client.lock().await;
+                let result = client.inspect(InspectRequest {}).await;
+                sender
+                    .send(result)
+                    .await
+                    .expect("The channel needs to be open")
+            });
+            while let Ok(result) = receiver.recv().await {
+                match result {
+                    Ok(response) => {
+                        let reply = response.into_inner();
+                        self.imp()
+                            .kernel_version_row
+                            .set_subtitle(&reply.kernel_version);
+                        self.imp().system_uptime_row.set_subtitle(
+                            &format_duration(Duration::from_secs(reply.system_uptime)).to_string(),
+                        );
+                    }
+                    Err(_) => {}
+                }
+            }
+            self.set_busy(false);
+        }
+    }
+    pub fn set_busy(&self, busy: bool) {
+        self.upcast_ref::<OperationPage>().set_busy(busy);
+        self.imp().activity_spinner.set_visible(busy);
+        self.imp().refresh_button.set_sensitive(!busy);
+    }
+}

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -6,16 +6,12 @@
 // SPDX-License-Identifier: MIT
 //
 
-mod batch_execution_page;
 mod connection_bar;
 mod connection_status_page;
-mod inspection_page;
 mod operation_page;
 mod operations_row;
 
-pub use batch_execution_page::*;
 pub use connection_bar::*;
 pub use connection_status_page::*;
-pub use inspection_page::*;
 pub use operation_page::*;
 pub use operations_row::*;

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,10 +24,8 @@ use crate::application::Application;
 use crate::client::{self, ArtifexClient};
 use crate::config::{APP_ID, PROFILE};
 use crate::i18n::i18n;
-use crate::widgets::{
-    BatchExecutionPage, ConnectionBar, ConnectionStatusPage, InspectionPage, OperationPage,
-    OperationsRow,
-};
+use crate::pages::{BatchExecutionPage, InspectionPage};
+use crate::widgets::{ConnectionBar, ConnectionStatusPage, OperationPage, OperationsRow};
 
 mod imp {
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,7 +24,7 @@ use crate::application::Application;
 use crate::client::{self, ArtifexClient};
 use crate::config::{APP_ID, PROFILE};
 use crate::i18n::i18n;
-use crate::pages::{BatchExecutionPage, InspectionPage};
+use crate::pages::{BatchExecutionPage, ExecutionPage, InspectionPage};
 use crate::widgets::{ConnectionBar, ConnectionStatusPage, OperationPage, OperationsRow};
 
 mod imp {
@@ -45,6 +45,8 @@ mod imp {
         #[template_child]
         pub inspection_page: TemplateChild<InspectionPage>,
         #[template_child]
+        pub execution_page: TemplateChild<ExecutionPage>,
+        #[template_child]
         pub batch_execution_page: TemplateChild<BatchExecutionPage>,
         #[template_child]
         pub stack: TemplateChild<gtk::Stack>,
@@ -60,6 +62,7 @@ mod imp {
                 operations_list: TemplateChild::default(),
                 connection_status_page: TemplateChild::default(),
                 inspection_page: TemplateChild::default(),
+                execution_page: TemplateChild::default(),
                 batch_execution_page: TemplateChild::default(),
                 stack: TemplateChild::default(),
                 settings: gio::Settings::new(APP_ID),
@@ -192,6 +195,10 @@ impl Window {
         if let Some(client) = self.imp().client.borrow().deref() {
             self.imp()
                 .inspection_page
+                .upcast_ref::<OperationPage>()
+                .set_client(Some(client.clone()));
+            self.imp()
+                .execution_page
                 .upcast_ref::<OperationPage>()
                 .set_client(Some(client.clone()));
             self.imp()


### PR DESCRIPTION
This PR adds basic support for executing a command on a remote device by adding a page "System Execution".

Some improvements are required:

- automatically scrolling the command history.
- adding support for clearing command history.