### PR TITLE
Improve remote command execution

### DIFF
--- a/data/resources/ui/execution_page.blp
+++ b/data/resources/ui/execution_page.blp
@@ -31,6 +31,14 @@ template $ExecutionPage : $OperationPage {
         trigger: "<Control>x";
         action: "action(execution-page.execute-command)";
       }
+      Shortcut {
+        trigger: "<Control>Delete";
+        action: "action(execution-page.clear-commands)";
+      }
     }
   }
 }
+
+menu execution_menu {
+   item(_("Clear commands"), "execution-page.clear-commands")
+ }

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -53,6 +53,12 @@
                 <property name="accelerator">&lt;Control&gt;x</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Clear commands</property>
+                <property name="accelerator">&lt;Control&gt;Delete</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/src/pages/execution/commands_view.rs
+++ b/src/pages/execution/commands_view.rs
@@ -6,7 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-use gtk::{glib, subclass::prelude::*};
+use glib::clone;
+use gtk::{glib, prelude::*, subclass::prelude::*};
 
 mod imp {
     use super::*;
@@ -59,5 +60,36 @@ impl CommandsView {
 
     pub fn set_factory(&self, factory: Option<&impl glib::object::IsA<gtk::ListItemFactory>>) {
         self.imp().list_view.set_factory(factory)
+    }
+
+    pub fn scroll_to_last(&self) {
+        let model = self
+            .imp()
+            .list_view
+            .model()
+            .expect("CommandsView must have a SelectionModel");
+        let n_items = model.n_items();
+        if n_items > 0 {
+            // FIXME: This is an ugly hack.
+            // One could think of using glib::idle_add_local_once(),
+            // but as this function is called from an async function,
+            // this won't work.
+            // So use a timeout value "good enough" for small commamd
+            // output.
+            glib::timeout_add_local_once(
+                std::time::Duration::from_millis(1000),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move || {
+                        this.imp().list_view.scroll_to(
+                            n_items - 1,
+                            gtk::ListScrollFlags::FOCUS,
+                            None,
+                        );
+                    }
+                ),
+            );
+        }
     }
 }

--- a/src/pages/execution/execution_page.rs
+++ b/src/pages/execution/execution_page.rs
@@ -165,7 +165,7 @@ impl ExecutionPage {
             self.set_busy(true);
             let cmd_text = self.imp().command_bar.command();
             let cmd_input = Command::new(&cmd_text);
-            self.imp().commands.append(&cmd_input);
+            self.append_command(&cmd_input);
             let (sender, receiver) =
                 async_channel::bounded::<Result<tonic::Response<ExecuteReply>, tonic::Status>>(1);
             client::runtime().spawn(async move {
@@ -189,7 +189,7 @@ impl ExecutionPage {
                             CommandStatus::Ko
                         };
                         cmd_output.set_status(status);
-                        self.imp().commands.append(&cmd_output);
+                        self.append_command(&cmd_output);
                     }
                     Err(e) => {
                         error!("Command execution failed: {}", e.to_string());
@@ -215,5 +215,10 @@ impl ExecutionPage {
 
     fn clear_commands(&self) {
         self.imp().commands.remove_all();
+    }
+
+    fn append_command(&self, command: &Command) {
+        self.imp().commands.append(command);
+        self.imp().commands_view.scroll_to_last();
     }
 }

--- a/src/pages/execution/execution_page.rs
+++ b/src/pages/execution/execution_page.rs
@@ -27,6 +27,9 @@ mod imp {
     #[derive(Debug, gtk::CompositeTemplate)]
     #[template(resource = "/com/elebihan/artifex-client-gtk/ui/execution_page.ui")]
     pub struct ExecutionPage {
+        pub menu_button: gtk::MenuButton,
+        #[template_child]
+        pub execution_menu: TemplateChild<gio::Menu>,
         #[template_child]
         pub commands_view: TemplateChild<CommandsView>,
         #[template_child]
@@ -50,6 +53,10 @@ mod imp {
                     page.execute_command().await
                 },
             );
+            klass.install_action("execution-page.clear-commands", None, move |page, _, _| {
+                debug!("execution-page.clear-commands");
+                page.clear_commands();
+            })
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -63,6 +70,14 @@ mod imp {
             self.obj()
                 .upcast_ref::<OperationPage>()
                 .set_title(&gettext("Execution"));
+            self.menu_button.set_icon_name("view-more-symbolic");
+            self.menu_button
+                .set_tooltip_text(Some(&gettext("Command execution menu")));
+            let menu_popover =
+                gtk::PopoverMenu::from_model(self.execution_menu.downcast_ref::<gio::Menu>());
+            self.menu_button.set_popover(Some(&menu_popover));
+            let header_bar = self.obj().upcast_ref::<OperationPage>().get_header_bar();
+            header_bar.pack_end(&self.menu_button);
             self.obj().setup_store();
             self.obj().setup_factory();
         }
@@ -74,6 +89,8 @@ mod imp {
     impl Default for ExecutionPage {
         fn default() -> Self {
             Self {
+                menu_button: gtk::MenuButton::new(),
+                execution_menu: TemplateChild::default(),
                 commands: gio::ListStore::new::<Command>(),
                 command_bar: gtk::TemplateChild::default(),
                 commands_view: gtk::TemplateChild::default(),
@@ -194,5 +211,9 @@ impl ExecutionPage {
         {
             command.set_status(status);
         }
+    }
+
+    fn clear_commands(&self) {
+        self.imp().commands.remove_all();
     }
 }


### PR DESCRIPTION
This PR improves execution of a remote command by:

- adding a shortcut to clear commands view.
- automatically scrolling the commands view to the last command added (either input or output).

The latter is achieved using an ugly hack, so there is room for improvement.